### PR TITLE
Migrate repository

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ workflows:
 jobs:
   build:
     docker:
-      - image: cimg/go:1.14
+      - image: cimg/go:1.16.3
     steps:
       - checkout
       - restore_cache:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,4 @@
+project_name: gravatar
+
+builds:
+  - skip: true

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright © 2020 Ricardo N Feliciano <Ricardo@Feliciano.Tech>
+Copyright © 2020-2021 Ricardo N Feliciano <Ricardo@Feliciano.Tech>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
-# Gravatar Go Library [![CircleCI Build Status](https://circleci.com/gh/revidian-cloud/go-gravatar.svg?style=shield)](https://circleci.com/gh/revidian-cloud/go-gravatar) [![Go Report Card](https://goreportcard.com/badge/github.com/revidian-cloud/go-gravatar)](https://goreportcard.com/report/github.com/revidian-cloud/go-gravatar) [![GitHub License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/revidian-cloud/go-gravatar/master/LICENSE)
+# Gravatar Go Module [![CI Status](https://circleci.com/gh/gopherlibs/gravatar.svg?style=shield)](https://app.circleci.com/pipelines/github/gopherlibs/gravatar) [![Go Report Card](https://goreportcard.com/badge/github.com/gopherlibs/gravatar)](https://goreportcard.com/report/github.com/gopherlibs/gravatar) [![Software License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/gopherlibs/gravatar/master/LICENSE)
 
-`go-gravatar` is a Go (Golang) module that allows you to generate Gravatar URLs easily in your own Go project.
+`gravatar` is a Go (Golang) module that allows you to generate Gravatar URLs easily in your own Go project.
 
 
 ## Requirements
 
-This Go module is tested with the two most recent minor releases of Go.
-Currently this is Go v1.13 and Go v1.14.
+This Go module is tested with the ~~two~~ most recent minor ~~releases~~ release of Go.
+Currently this is Go v1.16.
 
 
 ## Installation
 
-`go-gravatar` is a Go module and so the best way to use it is to import it into your own code and then run `go mod tidy` to get it downloaded.
+`gravatar` is a Go module and so the best way to use it is to import it into your own code and then run `go mod tidy` to get it downloaded.
 
 ```go
 import(
-	"github.com/revidian-cloud/go-gravatar/gravatar"
+	"github.com/gopherlibs/gravatar/gravatar"
 )
 ```
 
@@ -29,12 +29,12 @@ package main
 import (
 	"fmt"
 
-	"github.com/revidian-cloud/go-gravatar/gravatar"
+	"github.com/gopherlibs/gravatar/gravatar"
 )
 
 func main() {
 
-	img, err := gravatar.NewImage("FelicianoTech@gmail.com")
+	img, err := gravatar.NewImage("Ricardo@Feliciano.Tech")
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -53,7 +53,7 @@ func main() {
 
 ## Development
 
-This library is written and tested with Go v1.14+ in mind.
+This library is written and tested with Go v1.16+ in mind.
 `go fmt` is your friend.
 Please feel free to open Issues and PRs are you see fit.
 Any PR that requires a good amount of work or is a significant change, it would be best to open an Issue to discuss the change first.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/gopherlibs/gravatar/gravatar
+
+go 1.16

--- a/gravatar/go.mod
+++ b/gravatar/go.mod
@@ -1,3 +1,0 @@
-module github.com/revidian-cloud/go-gravatar/gravatar
-
-go 1.14


### PR DESCRIPTION
This repository is going from `revidian-cloud/go-gravatar` to
`gopherlibs/gravatar`. v0.3.0 should be the first release at its new
home.