### PR TITLE
Adds support to handle multiple emails for gravatar

### DIFF
--- a/gpic/gravatar_test.go
+++ b/gpic/gravatar_test.go
@@ -20,24 +20,27 @@ func TestNewImage(t *testing.T) {
 func TestImageURL(t *testing.T) {
 
 	samples := []struct {
-		email        string
+		emails       []string
 		emailHash    string
 		defaultImage string
 		rating       rating
 		size         uint16
 		expectedURL  string
 	}{
-		{"Ricardo@Feliciano.Tech", "f6d625c59c19ea57fe2c3d7968a56f29", "", 0, 0, "https://www.gravatar.com/avatar/f6d625c59c19ea57fe2c3d7968a56f29.jpg?rating=g&size=80"},
-		{"Ricardo@Feliciano.Tech", "f6d625c59c19ea57fe2c3d7968a56f29", "", 0, 50, "https://www.gravatar.com/avatar/f6d625c59c19ea57fe2c3d7968a56f29.jpg?rating=g&size=50"},
-		{"Ricardo@Feliciano.Tech", "f6d625c59c19ea57fe2c3d7968a56f29", "", RatingR, 50, "https://www.gravatar.com/avatar/f6d625c59c19ea57fe2c3d7968a56f29.jpg?rating=r&size=50"},
-		{"Ricardo@Feliciano.Tech", "f6d625c59c19ea57fe2c3d7968a56f29", "", RatingR, 3000, "https://www.gravatar.com/avatar/f6d625c59c19ea57fe2c3d7968a56f29.jpg?rating=r&size=80"},
-		{"Ricardo@Feliciano.Tech", "f6d625c59c19ea57fe2c3d7968a56f29", "identicon", 0, 0, "https://www.gravatar.com/avatar/f6d625c59c19ea57fe2c3d7968a56f29.jpg?default=identicon&rating=g&size=80"},
-		{"Ricardo@Feliciano.Tech", "f6d625c59c19ea57fe2c3d7968a56f29", "retro", RatingPG, 2000, "https://www.gravatar.com/avatar/f6d625c59c19ea57fe2c3d7968a56f29.jpg?default=retro&rating=pg&size=2000"},
+		{[]string{"info@chayev.com","Ricardo@Feliciano.Tech"}, "f6d625c59c19ea57fe2c3d7968a56f29", "", 0, 0, "https://www.gravatar.com/avatar/f6d625c59c19ea57fe2c3d7968a56f29.jpg?rating=g&size=80"},
+		{[]string{"Ricardo@Feliciano.Tech"}, "f6d625c59c19ea57fe2c3d7968a56f29", "", 0, 0, "https://www.gravatar.com/avatar/f6d625c59c19ea57fe2c3d7968a56f29.jpg?rating=g&size=80"},
+		{[]string{"Ricardo@Feliciano.Tech"}, "f6d625c59c19ea57fe2c3d7968a56f29", "", 0, 50, "https://www.gravatar.com/avatar/f6d625c59c19ea57fe2c3d7968a56f29.jpg?rating=g&size=50"},
+		{[]string{"Ricardo@Feliciano.Tech"}, "f6d625c59c19ea57fe2c3d7968a56f29", "", RatingR, 50, "https://www.gravatar.com/avatar/f6d625c59c19ea57fe2c3d7968a56f29.jpg?rating=r&size=50"},
+		{[]string{"Ricardo@Feliciano.Tech"}, "f6d625c59c19ea57fe2c3d7968a56f29", "", RatingR, 3000, "https://www.gravatar.com/avatar/f6d625c59c19ea57fe2c3d7968a56f29.jpg?rating=r&size=80"},
+		{[]string{"Ricardo@Feliciano.Tech"}, "f6d625c59c19ea57fe2c3d7968a56f29", "identicon", 0, 0, "https://www.gravatar.com/avatar/f6d625c59c19ea57fe2c3d7968a56f29.jpg?default=identicon&rating=g&size=80"},
+		{[]string{"Ricardo@Feliciano.Tech"}, "f6d625c59c19ea57fe2c3d7968a56f29", "retro", RatingPG, 2000, "https://www.gravatar.com/avatar/f6d625c59c19ea57fe2c3d7968a56f29.jpg?default=retro&rating=pg&size=2000"},
+		{[]string{"info@chayev.com"}, "328576744df0329b287e83fb6257ebb5", "", 0, 50, "https://www.gravatar.com/avatar/328576744df0329b287e83fb6257ebb5.jpg?rating=g&size=50"},
+		{[]string{"Ricardo@Feliciano.Tech","info@chayev.com"}, "f6d625c59c19ea57fe2c3d7968a56f29", "", RatingR, 50, "https://www.gravatar.com/avatar/f6d625c59c19ea57fe2c3d7968a56f29.jpg?d=404&rating=r&size=50"},
 	}
 
-	for _, sample := range samples {
+	for idx, sample := range samples {
 
-		i, err := NewImage(sample.email)
+		i, err := NewImage(sample.emails...)
 		if err != nil {
 			t.Errorf("Failed creating new image.")
 		}
@@ -45,9 +48,9 @@ func TestImageURL(t *testing.T) {
 		i.defaultImage = sample.defaultImage
 		i.SetSize(sample.size)
 		i.rating = sample.rating
-
+		
 		if url, _ := i.URL(); url.String() != sample.expectedURL {
-			t.Errorf(" got url: %q; expected: %q", url, sample.expectedURL)
+			t.Errorf(" got url: %q; expected: %q; #: %d\n", url, sample.expectedURL, idx)
 		}
 	}
 }


### PR DESCRIPTION
Added support to handle multiple emails in the NewImage function. This allows for multiple emails to be passed and the precedence is defined by the order that is passed. A default image is returned if the last email results in a default image. 

Tests were updated as well to ensure the logic is correct.