### PR TITLE
Remove trailing slash from GH_HOSTNAME as it is not needed.

### DIFF
--- a/gpic/github.go
+++ b/gpic/github.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 )
 
-const GH_HOSTNAME = "https://avatars.githubusercontent.com/"
+const GH_HOSTNAME = "https://avatars.githubusercontent.com"
 const GH_MAX_SIZE = 460
 
 type githubAvatar struct {


### PR DESCRIPTION
The current implementation adds 2 "/" in the avatar url. Fixing it so that it does not.